### PR TITLE
Add option to only restart the PostgreSQL service when needed

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -59,10 +59,10 @@ jobs:
         config:
           - name: rocky8
             image: "rockylinux"
-            tag: "8.7"
+            tag: "8.9"
           - name: rocky9
             image: "rockylinux"
-            tag: "9.1"
+            tag: "9.3"
           - name: debian11
             image: "debian"
             tag: "11"
@@ -85,7 +85,7 @@ jobs:
         with:
           path: "${{ github.repository }}"
       - name: molecule
-        uses: gofrolist/molecule-action@v2
+        uses: gofrolist/molecule-action@v2.7.40
         with:
           # molecule_options: --debug
           molecule_command: test

--- a/README.md
+++ b/README.md
@@ -150,10 +150,16 @@ postgresql_hba_raw: |
   host    all             all         127.0.0.1/32    md5
   host    all             all         ::1/128         md5
 
+# Allow service restart for configuration changes that require it
+postgresql_config_change_allow_restart: true
 
 ```
 
 _Notes:_
+
+By default, this role restarts the PostgreSQL service during subsequent configuration changes after the initial engine installation, ensuring all changes are applied immediately. However, this behavior can cause potential service outages.
+
+To prevent automatic restarts, you can set the variable `postgresql_config_change_allow_restart` (introduced in `v2.1.0`) to `false`. Starting with (`v3.0.0`), the default value of this variable will change to `false`, meaning the role will avoid restarting PostgreSQL by default. If you rely on the current behavior, you will need to explicitly set this variable to true in your configuration.
 
 In relation to HBA rules, you have the option to configure the variable `postgresql_hba_use_raw` as `true` and specify the contents of `postgresql_hba_raw`. These contents will be inserted directly into the `pg_hba.conf` file.
 
@@ -535,9 +541,6 @@ postgresql_data_dir:
 postgresql_initdb_extra_args: ''
 # Debian only. postgresql cluster name
 postgresql_cluster_name: main
-
-# Set postgresql state when configuration changes are made. Recommended values: `restarted` or `reloaded`
-postgresql_restarted_state: "restarted"
 
 # PostgreSQL system user/group
 postgresql_user: postgres

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ postgresql_unix_socket_directories:
 # Permissions for the PostgreSQL unix sockets (default is distro dependant)
 postgresql_unix_socket_directories_mode: ''
 # Allow service restart for configuration changes that require it
-postgresql_config_change_allow_restart: "{{ postgresql_restarted_state | d('restarted') == 'restarted' }}"
+postgresql_config_change_allow_restart: "{{ (postgresql_restarted_state | d('restarted')) == 'restarted' }}"
 
 
 # Global configuration options that will be set in postgresql.conf.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,8 @@ postgresql_unix_socket_directories:
   - /run/postgresql
 # Permissions for the PostgreSQL unix sockets (default is distro dependant)
 postgresql_unix_socket_directories_mode: ''
+# Allow service restart for configuration changes that require it
+postgresql_config_change_allow_restart: "{{ postgresql_restarted_state | d('restarted') == 'restarted' }}"
 
 
 # Global configuration options that will be set in postgresql.conf.
@@ -61,7 +63,7 @@ postgresql_log_dir: "{{ ((postgresql_global_config_options + postgresql_global_c
 postgresql_effective_log_dir: "{{ postgresql_log_dir is match('/') | ternary(postgresql_log_dir, _postgresql_data_dir ~ '/' ~ postgresql_log_dir) }}"
 # Permissions for the postgresql log directory
 postgresql_log_directory_mode: '0700'
-# Whether or not to create a tmpfiles.d postgresql file to persist permissions on unix socket directories and log directories accross system rebbots
+# Whether or not to create a tmpfiles.d postgresql file to persist permissions on unix socket directories and log directories accross system reboots
 postgresql_persist_permissions: true
 # Path to the template used by Ansible to create the tempfile conf to persist permissions
 # You can update this path to a custom file to completely customize the persisting rules
@@ -72,13 +74,6 @@ postgresql_tempfile_dest_path: /etc/tmpfiles.d/postgresql-common.conf
 postgresql_tempfile_mode: '0644'
 postgresql_tempfile_owner: root
 postgresql_tempfile_group: root
-
-# todo: how to handler configuration changes
-postgresql_config_change_handler: service_reload # service_[restart|reload] engine_reload=reload
-postgresql_config_change_allow_restart_1: false
-postgresql_config_change_allow_restart_2: false
-postgresql_config_change_tatoo_filepath: "{{ _postgresql_user_home_dir }}/.service_restarted.claranet.postgresql"
-postgresql_config_change_restart_tatoo: true
 
 # Host based authentication (hba) entries to be added to the pg_hba.conf. This
 # variable's defaults reflect the defaults that come with a fresh installation.
@@ -99,9 +94,6 @@ postgresql_hba_raw: ''
 postgresql_initdb_extra_args: ''
 # Debian only. postgresql cluster name
 postgresql_cluster_name: main
-
-# Set postgresql state when configuration changes are made. Recommended values: `restarted` or `reloaded`
-postgresql_restarted_state: "restarted"
 
 # PostgreSQL system user/group
 postgresql_user: postgres

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,13 +56,14 @@ postgresql_global_config_options:
 # Extra configuration options that are always inserted inside postgresql.conf
 postgresql_global_config_options_extra: []
 # Actual postgresql log directory
-postgresql_log_dir: "{{ ((postgresql_global_config_options + postgresql_global_config_options_extra) | items2dict(key_name='option', value_name='value')).log_directory }}"
+postgresql_log_dir: "{{ ((postgresql_global_config_options + postgresql_global_config_options_extra) |
+  items2dict(key_name='option', value_name='value')).log_directory }}"
 postgresql_effective_log_dir: "{{ postgresql_log_dir is match('/') | ternary(postgresql_log_dir, _postgresql_data_dir ~ '/' ~ postgresql_log_dir) }}"
 # Permissions for the postgresql log directory
 postgresql_log_directory_mode: '0700'
-# Whether or not to create a tmpfiles.d postgresql file to persist permissions on unix socket directories and log directories accross system rebbots 
+# Whether or not to create a tmpfiles.d postgresql file to persist permissions on unix socket directories and log directories accross system rebbots
 postgresql_persist_permissions: true
-# Path to the template used by Ansible to create the tempfile conf to persist permissions 
+# Path to the template used by Ansible to create the tempfile conf to persist permissions
 # You can update this path to a custom file to completely customize the persisting rules
 postgresql_tempfile_src_template_path: etc/tmpfiles.d/postgresql-common.conf.j2
 # Destination path for the tempfile configuration
@@ -71,6 +72,13 @@ postgresql_tempfile_dest_path: /etc/tmpfiles.d/postgresql-common.conf
 postgresql_tempfile_mode: '0644'
 postgresql_tempfile_owner: root
 postgresql_tempfile_group: root
+
+# todo: how to handler configuration changes
+postgresql_config_change_handler: service_reload # service_[restart|reload] engine_reload=reload
+postgresql_config_change_allow_restart_1: false
+postgresql_config_change_allow_restart_2: false
+postgresql_config_change_tatoo_filepath: "{{ _postgresql_user_home_dir }}/.service_restarted.claranet.postgresql"
+postgresql_config_change_restart_tatoo: true
 
 # Host based authentication (hba) entries to be added to the pg_hba.conf. This
 # variable's defaults reflect the defaults that come with a fresh installation.
@@ -216,7 +224,7 @@ postgresql_replication_create_slot: true
 postgresql_replication_primary_inventory_name: ""
 # ip addresses/dns names used to generate replication hba entries that allow replicas to connect to the primary server
 postgresql_replication_replica_addresses: []
-# User provided replication specific hba rules, if empty the role will automatically create the rules to autorize each replica 
+# User provided replication specific hba rules, if empty the role will automatically create the rules to autorize each replica
 # Check _postgresql_replication_hba_entries variable in vars/main.yml
 postgresql_replication_hba_entries: []
 # Authentication method specific for the replica hosts

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,3 +9,12 @@
     state: "{{ postgresql_restarted_state }}"
     enabled: "{{ postgresql_service_enabled }}"
     sleep: 5
+
+# - name: Advanced_handle_config_change
+#   ansible.builtin.include_tasks: tasks/handlers/config_change.yml
+
+- name: Reload postgresql
+  ansible.builtin.service:
+    name: "{{ _postgresql_daemon }}"
+    state: "reloaded"
+    sleep: 5

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,20 +1,9 @@
 ---
 - name: Reload systemd
   ansible.builtin.systemd:
-    daemon_reload: true
-
-- name: Restart postgresql
-  ansible.builtin.service:
-    name: "{{ _postgresql_daemon }}"
-    state: "{{ postgresql_restarted_state }}"
-    enabled: "{{ postgresql_service_enabled }}"
-    sleep: 5
-
-# - name: Advanced_handle_config_change
-#   ansible.builtin.include_tasks: tasks/handlers/config_change.yml
 
 - name: Reload postgresql
   ansible.builtin.service:
     name: "{{ _postgresql_daemon }}"
-    state: "reloaded"
+    state: "{{ _postgresql_config_change_handler_state }}"
     sleep: 5

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,6 +3,8 @@
   hosts: all
   become: true
   gather_facts: true
+  vars_files:
+    - vars/main_default.yml
 
   pre_tasks:
     - name: Template out the temporary sql script

--- a/molecule/shared/tasks/verify_default.yml
+++ b/molecule/shared/tasks/verify_default.yml
@@ -4,6 +4,7 @@
     - name: "Retrieve package facts"
       ansible.builtin.package_facts:
         manager: auto
+      no_log: true
 
     # - name: show ansible_facts.packages
     #   ansible.builtin.debug:

--- a/molecule/shared/vars/main_default.yml
+++ b/molecule/shared/vars/main_default.yml
@@ -1,4 +1,2 @@
 ---
 postgresql_max_connections: 200
-postgresql_config_change_allow_restart_1: true
-postgresql_config_change_allow_restart_2: true

--- a/molecule/shared/vars/main_default.yml
+++ b/molecule/shared/vars/main_default.yml
@@ -1,0 +1,4 @@
+---
+postgresql_max_connections: 200
+postgresql_config_change_allow_restart_1: true
+postgresql_config_change_allow_restart_2: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,7 +9,6 @@
   loop: "{{ postgresql_autotune_config_options |
     community.general.lists_mergeby(postgresql_global_config_options, 'option') |
     community.general.lists_mergeby(postgresql_global_config_options_extra, 'option') }}"
-  # notify: Restart postgresql
   notify: Reload postgresql
 
 - name: Configure host based authentication (if entries are configured).
@@ -21,7 +20,6 @@
     backup: true
     mode: "600"
   diff: true
-  # notify: Restart postgresql
   notify: Reload postgresql
 # Not using the postgresql_hba module because it entailed having
 # a task to ensure the file is empty of default rules
@@ -64,14 +62,14 @@
     login_user: "{{ postgresql_user }}"
     login_unix_socket: "{{ postgresql_unix_socket_directories[0] }}"
   register: _postgresql_res_pending_params
-  # changed_when: _postgresql_res_pending_params.rowcount > 0
+  changed_when: postgresql_config_change_allow_restart and _postgresql_res_pending_params.rowcount > 0
   become: true
   become_user: "{{ postgresql_user }}"
   vars:
     ansible_ssh_pipelining: true
     ansible_python_interpreter: "{{ _postgresql_ansible_python_interpreter }}"
 
-- name: Handle params requiring a full restart to be taken into account
+- name: Handle params requiring a full restart
   when: _postgresql_res_pending_params.rowcount > 0
   block:
     - name: Extract param names
@@ -79,14 +77,12 @@
         _postgresql_pending_params_str: "'{{ _postgresql_res_pending_params.query_result | map(attribute='name') | list | join(',') }}'"
 
     - name: Display params awaiting restart
-      when: not postgresql_config_change_allow_restart
       ansible.builtin.debug:
         msg: >-
-          The following configuration parameters are pending a restart for their new values to take effect:
+          [WARNING]: THE FOLLOWING CONFIGURATION PARAMETERS ARE PENDING A RESTART FOR THEIR NEW VALUES TO TAKE EFFECT:
           {{ _postgresql_pending_params_str }}.
 
-          To enable a full service restart (which may cause downtime), set
-          `postgresql_config_change_allow_restart` to `true`.
+          TO ENABLE A FULL SERVICE RESTART (WHICH MAY CAUSE DOWNTIME), ENSURE `postgresql_config_change_allow_restart` IS `true`.
 
     - name: Restart service
       when: postgresql_config_change_allow_restart

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,7 +9,8 @@
   loop: "{{ postgresql_autotune_config_options |
     community.general.lists_mergeby(postgresql_global_config_options, 'option') |
     community.general.lists_mergeby(postgresql_global_config_options_extra, 'option') }}"
-  notify: Restart postgresql
+  # notify: Restart postgresql
+  notify: Reload postgresql
 
 - name: Configure host based authentication (if entries are configured).
   ansible.builtin.template:
@@ -20,7 +21,8 @@
     backup: true
     mode: "600"
   diff: true
-  notify: Restart postgresql
+  # notify: Restart postgresql
+  notify: Reload postgresql
 # Not using the postgresql_hba module because it entailed having
 # a task to ensure the file is empty of default rules
 # a task to add the rules.
@@ -54,3 +56,40 @@
 
 - name: Ensure postgresql service is running with latest up to date configuration
   ansible.builtin.meta: flush_handlers
+
+- name: Retrieve settings requiring a restart
+  community.postgresql.postgresql_query:
+    query: select name from pg_settings where pending_restart='true';
+    port: "{{ postgresql_port }}"
+    login_user: "{{ postgresql_user }}"
+    login_unix_socket: "{{ postgresql_unix_socket_directories[0] }}"
+  register: _postgresql_res_pending_params
+  # changed_when: _postgresql_res_pending_params.rowcount > 0
+  become: true
+  become_user: "{{ postgresql_user }}"
+  vars:
+    ansible_ssh_pipelining: true
+    ansible_python_interpreter: "{{ _postgresql_ansible_python_interpreter }}"
+
+- name: Handle params requiring a full restart to be taken into account
+  when: _postgresql_res_pending_params.rowcount > 0
+  block:
+    - name: Extract param names
+      ansible.builtin.set_fact:
+        _postgresql_pending_params_str: "'{{ _postgresql_res_pending_params.query_result | map(attribute='name') | list | join(',') }}'"
+
+    - name: Display params awaiting restart
+      when: not postgresql_config_change_allow_restart
+      ansible.builtin.debug:
+        msg: >-
+          The following configuration parameters are pending a restart for their new values to take effect:
+          {{ _postgresql_pending_params_str }}.
+
+          To enable a full service restart (which may cause downtime), set
+          `postgresql_config_change_allow_restart` to `true`.
+
+    - name: Restart service
+      when: postgresql_config_change_allow_restart
+      ansible.builtin.service:
+        name: "{{ _postgresql_daemon }}"
+        state: restarted

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -43,6 +43,10 @@
     virtualenv: "{{ _postgresql_virtualenv_path }}"
     virtualenv_command: python3 -m venv
   become_user: "{{ postgresql_user }}"
+  # check_mode: false
+  when: not ansible_check_mode
+  # register: _postgresql_res_venv_install
+  # changed_when: 'Collecting' in _postgresql_res_venv_install.stdout
   environment: "{{ _postgresql_general_proxy_env | ansible.builtin.combine({'PATH': _postgresql_pythonized_path}) }}"
 
 # Errors while installing this dependency on redhat system. Used the link below to provide a solution

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -43,10 +43,7 @@
     virtualenv: "{{ _postgresql_virtualenv_path }}"
     virtualenv_command: python3 -m venv
   become_user: "{{ postgresql_user }}"
-  # check_mode: false
   when: not ansible_check_mode
-  # register: _postgresql_res_venv_install
-  # changed_when: 'Collecting' in _postgresql_res_venv_install.stdout
   environment: "{{ _postgresql_general_proxy_env | ansible.builtin.combine({'PATH': _postgresql_pythonized_path}) }}"
 
 # Errors while installing this dependency on redhat system. Used the link below to provide a solution

--- a/tasks/redhat/initialize.yml
+++ b/tasks/redhat/initialize.yml
@@ -9,11 +9,9 @@
   notify:
     - Reload systemd
     - Reload postgresql
-    # - Restart postgresql
   when:
     - _postgresql_service_path | length > 0
   tags: skip_ansible_lint
-
 
 # Not using postgresql-XX-setup cause it didnt consistent output regarding the success or failure reason of an execution
 - name: Ensure PostgreSQL database is initialized

--- a/tasks/redhat/initialize.yml
+++ b/tasks/redhat/initialize.yml
@@ -8,7 +8,8 @@
     state: present
   notify:
     - Reload systemd
-    - Restart postgresql
+    - Reload postgresql
+    # - Restart postgresql
   when:
     - _postgresql_service_path | length > 0
   tags: skip_ansible_lint

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -24,6 +24,8 @@ _postgresql_replication_hba_entries: "{{ postgresql_replication_hba_entries }}"
 _postgresql_general_proxy_env: {}
 # Env var used to provide specified proxies to package manager tasks
 _postgresql_pkg_proxy_env: {}
+# How to handle configuration changes
+_postgresql_config_change_handler_state: reloaded
 
 _postgresql_apt_mirror_url: http://apt.postgresql.org/pub/repos/apt
 _postgresql_repo_rpm_url: "https://download.postgresql.org/pub/repos/yum/reporpms/{{ (ansible_distro == 'fedora') | ternary('F', 'EL') }}-{{ ansible_distribution_major_version }}-x86_64/pgdg-{{ (ansible_distro == 'fedora') | ternary('fedora', 'redhat') }}-repo-latest.noarch.rpm"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add option to only restart the PostgreSQL service when needed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #16 
closes #7 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests performed with Molecule both locally and using Github Actions

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] feat: add var `postgresql_config_change_allow_restart` to allow only restarting the PostgreSQL service when needed
- [x] chore: update rockylinux images used in github actions and pinned molecule-action to v2.7.40
- [x] fix(install): venv creation tasks always reporting as changed in dry-run has been with `when: not ansible_check_mode`


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
