### PR TITLE
Backport https://github.com/claranet/ansible-role-postgresql/pull/19 to version 1.0.0

### DIFF
--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -13,4 +13,4 @@ jobs:
         uses: robertdebock/galaxy-action@1.2.1
         with:
           galaxy_api_key: ${{ secrets.galaxy_api_key }}
-          git_branch: main
+          git_branch: release/1.1.0

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,102 +1,98 @@
 ---
-name: Ansible Molecule
-
-on:  # yamllint disable-line rule:truthy
-  push:
-    tags_ignore:
-      - '*'
-  pull_request:
-
-jobs:
-  setup:
-    name: Setup scenarios matrix
-    runs-on: ubuntu-22.04
-    outputs:
-      scenarios: ${{ steps.matrix.outputs.scenarios }}
-    steps:
-      - uses: actions/checkout@v3
-      - id: matrix
-        run: |
-          JSON="["
-
-          for s in $(find molecule -mindepth 1 -maxdepth 1 -type d -exec basename "{}" \;); do
-              if [ -e "molecule/${s}/molecule.yml" ]; then
-                  JSON="${JSON}\"${s}\","
-              fi
-          done
-
-          JSON="${JSON%?}"
-          JSON="$JSON]"
-
-          echo "::set-output name=scenarios::$(echo $JSON)"
-
-  lint:
-    name: Lint
-    needs:
-      - setup
-    runs-on: ubuntu-22.04
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-        with:
-          path: "${{ github.repository }}"
-      - name: Run ansible lint
-        uses: ansible/ansible-lint-action@v6.17.0
-        with:
-          path: "."
-
-  test:
-    name: Scenario "${{ matrix.scenario }}", pg-${{ matrix.postgresql_version }} on ${{ matrix.config.image }}:${{ matrix.config.tag }}
-    needs:
-      - lint
-      - setup
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        scenario: ${{ fromJson(needs.setup.outputs.scenarios) }}
-        postgresql_version:
-          - 15
-        config:
-          - name: rocky8
-            image: "rockylinux"
-            tag: "8.7"
-          - name: rocky9
-            image: "rockylinux"
-            tag: "9.1"
-          - name: debian10
-            image: "debian"
-            tag: "10"
-          - name: debian11
-            image: "debian"
-            tag: "11"
-          - name: debian12
-            image: "debian"
-            tag: "12"
-          - name: ubuntu20
-            image: "ubuntu"
-            tag: "20.04"
-          - name: ubuntu22
-            image: "ubuntu"
-            tag: "22.04"
-          - name: ubuntu24
-            image: "ubuntu"
-            tag: "24.04"
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-        with:
-          path: "${{ github.repository }}"
-      - name: molecule
-        uses: gofrolist/molecule-action@v2
-        with:
-          # molecule_options: --debug
-          molecule_command: test
-          molecule_args: --scenario-name ${{ matrix.scenario }} -d docker
-          molecule_working_dir: "${{ github.repository }}"
-        env:
-          image: ${{ matrix.config.image }}
-          tag: ${{ matrix.config.tag }}
-          name: ${{ matrix.config.name }}
-          postgresql_version: ${{ matrix.postgresql_version }}
+  name: Ansible Molecule
+  
+  on:  # yamllint disable-line rule:truthy
+    push:
+      tags_ignore:
+        - '*'
+    pull_request:
+  
+  jobs:
+    setup:
+      name: Setup scenarios matrix
+      runs-on: ubuntu-22.04
+      outputs:
+        scenarios: ${{ steps.matrix.outputs.scenarios }}
+      steps:
+        - uses: actions/checkout@v4
+        - id: matrix
+          run: |
+            JSON="["
+  
+            for s in $(find molecule -mindepth 1 -maxdepth 1 -type d -exec basename "{}" \;); do
+                if [ -e "molecule/${s}/molecule.yml" ]; then
+                    JSON="${JSON}\"${s}\","
+                fi
+            done
+  
+            JSON="${JSON%?}"
+            JSON="$JSON]"
+            echo "::set-output name=scenarios::$(echo $JSON)"
+  
+    lint:
+      name: Lint
+      needs:
+        - setup
+      runs-on: ubuntu-22.04
+      steps:
+        - name: checkout
+          uses: actions/checkout@v4
+          with:
+            path: "${{ github.repository }}"
+        - name: Run ansible lint
+          uses: ansible/ansible-lint-action@v6.17.0
+          with:
+            path: "."
+  
+    test:
+      name: Scenario "${{ matrix.scenario }}", pg-${{ matrix.postgresql_version }} on ${{ matrix.config.image }}:${{ matrix.config.tag }}
+      needs:
+        - lint
+        - setup
+      runs-on: ubuntu-20.04
+      strategy:
+        fail-fast: false
+        matrix:
+          scenario: ${{ fromJson(needs.setup.outputs.scenarios) }}
+          postgresql_version:
+            - 16
+          config:
+            - name: rocky8
+              image: "rockylinux"
+              tag: "8.9"
+            - name: rocky9
+              image: "rockylinux"
+              tag: "9.3"
+            - name: debian11
+              image: "debian"
+              tag: "11"
+            - name: debian12
+              image: "debian"
+              tag: "12"
+            - name: ubuntu20
+              image: "ubuntu"
+              tag: "20.04"
+            - name: ubuntu22
+              image: "ubuntu"
+              tag: "22.04"
+            - name: ubuntu24
+              image: "ubuntu"
+              tag: "24.04"
+  
+      steps:
+        - name: checkout
+          uses: actions/checkout@v4
+          with:
+            path: "${{ github.repository }}"
+        - name: molecule
+          uses: gofrolist/molecule-action@v2.7.40
+          with:
+            # molecule_options: --debug
+            molecule_command: test
+            molecule_args: --scenario-name ${{ matrix.scenario }} -d docker
+            molecule_working_dir: "${{ github.repository }}"
+          env:
+            image: ${{ matrix.config.image }}
+            tag: ${{ matrix.config.tag }}
+            name: ${{ matrix.config.name }}
+            postgresql_version: ${{ matrix.postgresql_version }}

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ postgresql_hba_raw: |
 
 _Notes:_
 
+By default, this role restarts the PostgreSQL service during subsequent configuration changes after the initial engine installation, ensuring all changes are applied immediately. However, this behavior can cause potential service outages.
+
+To prevent automatic restarts, you can set the variable `postgresql_config_change_allow_restart` (introduced in `v2.1.0`) to `false`. Starting with (`v3.0.0`), the default value of this variable will change to `false`, meaning the role will avoid restarting PostgreSQL by default. If you rely on the current behavior, you will need to explicitly set this variable to true in your configuration.
+
 In relation to HBA rules, you have the option to configure the variable `postgresql_hba_use_raw` as `true` and specify the contents of `postgresql_hba_raw`. These contents will be inserted directly into the `pg_hba.conf` file.
 
 Alternatively, if you possess a file containing these rules, you can set the `postgresql_hba_template_path` variable to the path of that file on the Ansible controller. In this case, the specified file will be copied to replace the `pg_hba.conf` file.
@@ -509,9 +513,6 @@ postgresql_data_dir:
 postgresql_initdb_extra_args: ''
 # Debian only. postgresql cluster name
 postgresql_cluster_name: main
-
-# Set postgresql state when configuration changes are made. Recommended values: `restarted` or `reloaded`
-postgresql_restarted_state: "restarted"
 
 # PostgreSQL system user/group
 postgresql_user: postgres

--- a/README.md
+++ b/README.md
@@ -149,14 +149,15 @@ postgresql_hba_raw: |
   host    all             all         127.0.0.1/32    md5
   host    all             all         ::1/128         md5
 
-
+# Allow service restart for configuration changes that require it
+postgresql_config_change_allow_restart: true
 ```
 
 _Notes:_
 
 By default, this role restarts the PostgreSQL service during subsequent configuration changes after the initial engine installation, ensuring all changes are applied immediately. However, this behavior can cause potential service outages.
 
-To prevent automatic restarts, you can set the variable `postgresql_config_change_allow_restart` (introduced in `v2.1.0`) to `false`. Starting with (`v3.0.0`), the default value of this variable will change to `false`, meaning the role will avoid restarting PostgreSQL by default. If you rely on the current behavior, you will need to explicitly set this variable to true in your configuration.
+To prevent automatic restarts, you can set the variable `postgresql_config_change_allow_restart` (introduced in `v2.1.0`) to `false`. Starting with (`v3.0.0`), the default value of this variable will change to `false`, meaning the role will avoid restarting PostgreSQL by default. If you rely on the current behavior, you will need to explicitly set this variable to `true` in your configuration.
 
 In relation to HBA rules, you have the option to configure the variable `postgresql_hba_use_raw` as `true` and specify the contents of `postgresql_hba_raw`. These contents will be inserted directly into the `pg_hba.conf` file.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,8 @@ postgresql_unix_socket_directories:
   - /run/postgresql
 # Permissions for the PostgreSQL unix sockets (default is distro dependant)
 postgresql_unix_socket_directories_mode: ''
-
+# Allow service restart for configuration changes that require it
+postgresql_config_change_allow_restart: "{{ postgresql_restarted_state | d('restarted') == 'restarted' }}"
 
 # Global configuration options that will be set in postgresql.conf.
 postgresql_global_config_options:
@@ -91,9 +92,6 @@ postgresql_hba_raw: ''
 postgresql_initdb_extra_args: ''
 # Debian only. postgresql cluster name
 postgresql_cluster_name: main
-
-# Set postgresql state when configuration changes are made. Recommended values: `restarted` or `reloaded`
-postgresql_restarted_state: "restarted"
 
 # PostgreSQL system user/group
 postgresql_user: postgres

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,9 +3,8 @@
   ansible.builtin.systemd:
     daemon_reload: true
 
-- name: Restart postgresql
+- name: Reload postgresql
   ansible.builtin.service:
     name: "{{ _postgresql_daemon }}"
-    state: "{{ postgresql_restarted_state }}"
-    enabled: "{{ postgresql_service_enabled }}"
+    state: "{{ _postgresql_config_change_handler_state }}"
     sleep: 5

--- a/molecule/shared/vars/main.yml
+++ b/molecule/shared/vars/main.yml
@@ -5,6 +5,7 @@ postgresql_listen_addresses: 0.0.0.0
 postgresql_shared_preload_libraries:
   - pg_stat_statements
 postgresql_max_connections: 100
+postgresql_config_change_allow_restart: false
 # Custom configuration options provided by the user
 postgresql_global_config_options_extra:
   - option: log_statement

--- a/tasks/autotune.yml
+++ b/tasks/autotune.yml
@@ -32,7 +32,7 @@
       regex_replace('\\n+$', '', multiline=true) |
       regex_replace('=', ':', multiline=true) |
       from_yaml | dict2items(key_name='option', value_name='value') }}"
-  when: _postgresql_autotune_res is succeeded
+  when: not ansible_check_mode and _postgresql_autotune_res is succeeded
 
 - name: "Output autotune optimized settings"
   ansible.builtin.debug:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,7 +9,7 @@
   loop: "{{ postgresql_autotune_config_options |
     community.general.lists_mergeby(postgresql_global_config_options, 'option') |
     community.general.lists_mergeby(postgresql_global_config_options_extra, 'option') }}"
-  notify: Restart postgresql
+  notify: Reload postgresql
 
 - name: Configure host based authentication (if entries are configured).
   ansible.builtin.template:
@@ -20,7 +20,7 @@
     backup: true
     mode: "600"
   diff: true
-  notify: Restart postgresql
+  notify: Reload postgresql
 # Not using the postgresql_hba module because it entailed having
 # a task to ensure the file is empty of default rules
 # a task to add the rules.
@@ -54,3 +54,38 @@
 
 - name: Ensure postgresql service is running with latest up to date configuration
   ansible.builtin.meta: flush_handlers
+
+- name: Retrieve settings requiring a restart
+  community.postgresql.postgresql_query:
+    query: select name from pg_settings where pending_restart='true';
+    port: "{{ postgresql_port }}"
+    login_user: "{{ postgresql_user }}"
+    login_unix_socket: "{{ postgresql_unix_socket_directories[0] }}"
+  register: _postgresql_res_pending_params
+  changed_when: postgresql_config_change_allow_restart and _postgresql_res_pending_params.rowcount > 0
+  become: true
+  become_user: "{{ postgresql_user }}"
+  vars:
+    ansible_ssh_pipelining: true
+    ansible_python_interpreter: "{{ _postgresql_ansible_python_interpreter }}"
+
+- name: Handle params requiring a full restart
+  when: _postgresql_res_pending_params.rowcount > 0
+  block:
+    - name: Extract param names
+      ansible.builtin.set_fact:
+        _postgresql_pending_params_str: "'{{ _postgresql_res_pending_params.query_result | map(attribute='name') | list | join(',') }}'"
+
+    - name: Display params awaiting restart
+      ansible.builtin.debug:
+        msg: >-
+          [WARNING]: THE FOLLOWING CONFIGURATION PARAMETERS ARE PENDING A RESTART FOR THEIR NEW VALUES TO TAKE EFFECT:
+          {{ _postgresql_pending_params_str }}.
+
+          TO ENABLE A FULL SERVICE RESTART (WHICH MAY CAUSE DOWNTIME), ENSURE `postgresql_config_change_allow_restart` IS `true`.
+
+    - name: Restart service
+      when: postgresql_config_change_allow_restart
+      ansible.builtin.service:
+        name: "{{ _postgresql_daemon }}"
+        state: restarted

--- a/tasks/debian/install.yml
+++ b/tasks/debian/install.yml
@@ -7,7 +7,7 @@
     group: root
     mode: "644"
 
-- name: Add postgreqsl repository signing key
+- name: Add postgresql repository signing key
   ansible.builtin.uri:
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
     dest: /etc/apt/trusted.gpg.d/pgdb.asc

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -43,6 +43,7 @@
     virtualenv: "{{ _postgresql_virtualenv_path }}"
     virtualenv_command: python3 -m venv
   become_user: "{{ postgresql_user }}"
+  when: not ansible_check_mode
   environment: "{{ _postgresql_general_proxy_env | ansible.builtin.combine({'PATH': _postgresql_pythonized_path}) }}"
 
 # Errors while installing this dependency on redhat system. Used the link below to provide a solution

--- a/tasks/redhat/initialize.yml
+++ b/tasks/redhat/initialize.yml
@@ -8,7 +8,7 @@
     state: present
   notify:
     - Reload systemd
-    - Restart postgresql
+    - Reload postgresql
   when:
     - _postgresql_service_path | length > 0
   tags: skip_ansible_lint

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -24,6 +24,8 @@ _postgresql_replication_hba_entries: "{{ postgresql_replication_hba_entries }}"
 _postgresql_general_proxy_env: {}
 # Env var used to provide specified proxies to package manager tasks
 _postgresql_pkg_proxy_env: {}
+# How to handle configuration changes
+_postgresql_config_change_handler_state: reloaded
 
 _postgresql_apt_mirror_url: http://apt.postgresql.org/pub/repos/apt
 _postgresql_repo_rpm_url: "https://download.postgresql.org/pub/repos/yum/reporpms/{{ (ansible_distro == 'fedora') | ternary('F', 'EL') }}-{{ ansible_distribution_major_version }}-x86_64/pgdg-{{ (ansible_distro == 'fedora') | ternary('fedora', 'redhat') }}-repo-latest.noarch.rpm"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add option to only restart the PostgreSQL service when needed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Backport https://github.com/claranet/ansible-role-postgresql/pull/19 to version 1.0.0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests performed with Molecule both locally and using Github Actions

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] feat: add var `postgresql_config_change_allow_restart` to allow only restarting the PostgreSQL service when needed
- [x] chore: update rockylinux images used in github actions and pinned molecule-action to v2.7.40
- [x] fix(install): venv creation tasks always reporting as changed in dry-run has been with `when: not ansible_check_mode`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
