### PR TITLE
Ensure postgresql service is started after configuration even with no configuration change

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ If you want to uninstall a Postgresql installation with this role, set both vari
     postgresql_autotune: true
     # postgresql_autotune_base_url: http://192.168.56.101:3000
 
-    postgres_users_no_log: false
+    postgresql_users_no_log: false
     postgresql_users:
     # Create two groups 'group1' and 'group2' by making use of thr role_attr_flags attribute
       - name: group1

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Debian 12         | Yes  | Yes  | Yes  | Yes  |  Yes
 Ubuntu 20.04      | Yes  | Yes  | Yes  | Yes  |  Yes 
 Ubuntu 22.04      | Yes  | Yes  | Yes  | Yes  |  Yes 
 Ubuntu 24.04      | Yes  | Yes  | Yes  | Yes  |  Yes 
-RockyLinux 8.7    | Yes  | Yes  | Yes  | Yes  |  Yes 
-RockyLinux 9.1    | Yes  | Yes  | Yes  | Yes  |  Yes 
+RockyLinux 8.9    | Yes  | Yes  | Yes  | Yes  |  Yes 
+RockyLinux 9.3    | Yes  | Yes  | Yes  | Yes  |  Yes 
 Fedora 38         | No   | No   | No   | No   |  No  
 
 ## Role features in use

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -134,7 +134,7 @@ postgresql_users: []
 #   port: # defaults to not set
 #   state: # defaults to 'present'
 # Whether to output user data when managing users.
-postgres_users_no_log: true
+postgresql_users_no_log: true
 
 # Manage group/role memberships
 postgresql_memberships: []

--- a/molecule/shared/vars/main_all_features.yml
+++ b/molecule/shared/vars/main_all_features.yml
@@ -17,7 +17,7 @@ postgresql_hba_entries_extra: []
 postgresql_autotune: true
 # postgresql_autotune_base_url: http://192.168.56.101:3000
 
-postgres_users_no_log: false
+postgresql_users_no_log: false
 postgresql_users:
 # Create two groups 'group1' and 'group2' by making use of thr role_attr_flags attribute
   - name: group1

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -47,10 +47,11 @@
     mode: "{{ postgresql_tempfile_mode }}"
   when: postgresql_persist_permissions
 
-- name: Set postgresql service enabled state
+- name: Set postgresql service enabled and started state
   ansible.builtin.service:
     name: "{{ _postgresql_daemon }}"
     enabled: "{{ postgresql_service_enabled }}"
+    state: "{{ _postgresql_service_state | d(omit, true) }}"
 
 - name: Ensure postgresql service is running with latest up to date configuration
   ansible.builtin.meta: flush_handlers

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -46,7 +46,7 @@
     session_role: "{{ item.session_role | d(omit) }}"
     trust_input: "{{ item.trust_input | d(omit) }}"
   loop: "{{ postgresql_schemas }}"
-  no_log: "{{ postgres_users_no_log }}"
+  no_log: "{{ postgresql_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"
   vars:
@@ -76,7 +76,7 @@
     session_role: "{{ item.session_role | d(omit) }}"
     trust_input: "{{ item.trust_input | d(omit) }}"
   loop: "{{ postgresql_tables }}"
-  no_log: "{{ postgres_users_no_log }}"
+  no_log: "{{ postgresql_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"
   vars:

--- a/tasks/ownerships.yml
+++ b/tasks/ownerships.yml
@@ -15,7 +15,7 @@
     session_role: "{{ item.session_role | d(omit) }}"
     trust_input: "{{ item.trust_input | d(omit) }}"
   loop: "{{ postgresql_ownerships }}"
-  no_log: "{{ postgres_users_no_log }}"
+  no_log: "{{ postgresql_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"
   vars:
@@ -43,7 +43,7 @@
     session_role: "{{ item.session_role | d(omit) }}"
     trust_input: "{{ item.trust_input | d(omit) }}"
   loop: "{{ postgresql_privs }}"
-  no_log: "{{ postgres_users_no_log }}"
+  no_log: "{{ postgresql_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"
   vars:

--- a/tasks/redhat/install.yml
+++ b/tasks/redhat/install.yml
@@ -51,7 +51,7 @@
       environment: "{{ _postgresql_pkg_proxy_env }}"
 
 # prereqs to install psycopg2
-- name: Install gcc rockylinux
+- name: Install gcc
   ansible.builtin.dnf:
     name: gcc
     state: present

--- a/tasks/replication-primary.yml
+++ b/tasks/replication-primary.yml
@@ -12,7 +12,7 @@
     expires: infinity
     role_attr_flags: REPLICATION
     state: present
-  no_log: "{{ postgres_users_no_log }}"
+  no_log: "{{ postgresql_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"
   # See: https://github.com/ansible/ansible/issues/16048#issuecomment-229012509

--- a/tasks/sql.yml
+++ b/tasks/sql.yml
@@ -16,7 +16,7 @@
     session_role: "{{ item.session_role | d(omit) }}"
     trust_input: "{{ item.trust_input | d(omit) }}"
   loop: "{{ postgresql_queries }}"
-  no_log: "{{ postgres_users_no_log }}"
+  no_log: "{{ postgresql_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"
   vars:
@@ -40,7 +40,7 @@
     session_role: "{{ item.session_role | d(omit) }}"
     trust_input: "{{ item.trust_input | d(omit) }}"
   loop: "{{ postgresql_scripts }}"
-  no_log: "{{ postgres_users_no_log }}"
+  no_log: "{{ postgresql_users_no_log }}"
   changed_when: false
   become: true
   become_user: "{{ postgresql_user }}"

--- a/tasks/tablespaces.yml
+++ b/tasks/tablespaces.yml
@@ -14,7 +14,7 @@
   when: not postgresql_replication or postgresql_replication_role == "primary"
   become: true
   become_user: "{{ postgresql_user }}"
-  no_log: "{{ postgres_users_no_log }}"
+  no_log: "{{ postgresql_users_no_log }}"
   vars:
     ansible_ssh_pipelining: true
     ansible_python_interpreter: "{{ _postgresql_ansible_python_interpreter }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -22,7 +22,7 @@
   loop: "{{ postgresql_users }}"
   loop_control:
     label: "{{ item.name }}"
-  no_log: "{{ postgres_users_no_log }}"
+  no_log: "{{ postgresql_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"
   environment:
@@ -47,7 +47,7 @@
     session_role: "{{ item.session_role | d(omit) }}"
     trust_input: "{{ item.trust_input | d(omit) }}"
   loop: "{{ postgresql_memberships }}"
-  no_log: "{{ postgres_users_no_log }}"
+  no_log: "{{ postgresql_users_no_log }}"
   become: true
   become_user: "{{ postgresql_user }}"
   vars:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -26,6 +26,8 @@ _postgresql_general_proxy_env: {}
 _postgresql_pkg_proxy_env: {}
 # How to handle configuration changes
 _postgresql_config_change_handler_state: reloaded
+# Default service state after configuration regardless of configuration changes
+_postgresql_service_state: started
 
 _postgresql_apt_mirror_url: http://apt.postgresql.org/pub/repos/apt
 _postgresql_repo_rpm_url: "https://download.postgresql.org/pub/repos/yum/reporpms/{{ (ansible_distro == 'fedora') | ternary('F', 'EL') }}-{{ ansible_distribution_major_version }}-x86_64/pgdg-{{ (ansible_distro == 'fedora') | ternary('fedora', 'redhat') }}-repo-latest.noarch.rpm"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ensure postgresql service is started after configuration even with no configuration change

closes #22
closes #23

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests performed with Molecule both locally and using Github Actions

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] fix: ensure service is started
- [x] fix: remove rockylinux reference in task name
- [x] docs: update rocklylinux'version used for testing
- [x] typo: renamed to users no log var to proper prefix postgresql instead of postgres

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
